### PR TITLE
Feature/allow query naming

### DIFF
--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -14,6 +14,16 @@ function getQuery(shim, original, name, args) {
   return statement
 }
 
+function getQueryName(shim, original, name, args) {
+  var config = args[0]
+
+  if (config && config.name) {
+    return config.name
+  }
+
+  return null
+}
+
 module.exports = function initialize(agent, pgsql, moduleName, shim) {
   shim.setDatastore(shim.POSTGRES)
   // allows for native wrapping to not happen if not necessary
@@ -44,6 +54,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
     shim.recordQuery(this, 'query', {
       callback: shim.LAST,
       query: getQuery,
+      queryName: getQueryName,
       stream: 'row',
       parameters: getInstanceParameters(shim, this),
       internal: false
@@ -82,6 +93,7 @@ module.exports = function initialize(agent, pgsql, moduleName, shim) {
       return {
         callback: shim.LAST,
         query: getQuery,
+        queryName: getQueryName,
         stream: 'row',
         parameters: getInstanceParameters(shim, this),
         internal: false

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -728,7 +728,7 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     // If the intstrumentation provides a name use it, otherwise construct a name
     // from the parsed query string
     var name = queryName ? 
-      queryName : 
+      queryName + '/' + 'select' + suffix : 
       (parsed.collection || 'other') + '/' + parsed.operation + suffix
 
     // Return the segment descriptor.

--- a/lib/shim/datastore-shim.js
+++ b/lib/shim/datastore-shim.js
@@ -721,9 +721,15 @@ function _recordQuery(suffix, nodule, properties, querySpec) {
     }
     shim.logger.trace('Found query %j', queryStr)
 
+    var queryName = _extractQueryName.call(shim, fn, fnName, queryDesc, this, args)
+
     // Parse the query and assemble the name.
     var parsed = shim.parseQuery(queryStr, this)
-    var name = (parsed.collection || 'other') + '/' + parsed.operation + suffix
+    // If the intstrumentation provides a name use it, otherwise construct a name
+    // from the parsed query string
+    var name = queryName ? 
+      queryName : 
+      (parsed.collection || 'other') + '/' + parsed.operation + suffix
 
     // Return the segment descriptor.
     return {
@@ -825,6 +831,18 @@ function _extractQueryStr(fn, fnName, spec, ctx, args) {
   }
 
   return queryStr
+}
+
+function _extractQueryName(fn, fnName, spec, ctx, args) {
+  var queryName = spec.queryName
+  // Adds support for an instrumentation to specify
+  // a function to calculate a name that should be used
+  // for generating the transaction segment name for the query
+  if (!queryName || !this.isFunction(queryName)) {
+    return null
+  }
+
+  return queryName.call(ctx, this, fn, fnName, args)
 }
 
 /**


### PR DESCRIPTION
When the call to `node-postgresql`'s `client.query` method is made, if the call specifies a named prepared statement, take that name and use it in the generation of the segment name produced on the RecordDescriptor returned by the RecorderFunction passed to `Shim.record`
